### PR TITLE
Windows Integration pass

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,11 +1,10 @@
 @echo off
-
-REM build.bat is to build the current projects things into a useable exe
+cls
 
 set internalProgramFlags=
 
 set WarningFlags= -WX -W4 -wd4201 -wd4100 -wd4189 -wd4505 -wd4351
-set Flags= %internalProgramFlags% -Zi -EHsc -nologo -fp:fast -Gm- -GR- -EHa- -Od -Oi %WarningFlags%
+set Flags= %internalProgramFlags% -Zi -EHsc -nologo -fp:fast -Gm- -GR- -EHa- %WarningFlags%
 
 set LibsLinkedTo= user32.lib Gdi32.lib
 set LinkerFlags= -incremental:no -opt:ref -NODEFAULTLIB:library %LibsLinkedTo%
@@ -13,9 +12,7 @@ set LinkerFlags= -incremental:no -opt:ref -NODEFAULTLIB:library %LibsLinkedTo%
 IF NOT EXIST build mkdir build
 pushd build
 
-REM Clearing debug info so new information can be correctly stored
-REM rm *.pdb
+del rm *.pdb
 
-REM MSVC build
 cl %Flags% ..\win32main.cpp /link %LinkerFlags%
 popd

--- a/win32main.cpp
+++ b/win32main.cpp
@@ -31,7 +31,7 @@ bool ReadDictionaryFromXMLConfigFile()
     if(handle == NULL) { printf("\nFailed to open config file, please ensure \
             the xml file is in the same dir as you launched this from\n");
         return false; }
-    for(u8 i = 0; i < (NUMBER_OF_TAGS+1); i++)
+    for(u8 i = 0; i < (NUMBER_OF_TAGS); i++)
     {
         ExtractXMLNodeContents(handle, TagsOpen[i], TagsEnd[i], i);
     }

--- a/win32main.h
+++ b/win32main.h
@@ -1,7 +1,7 @@
 #ifndef WIN32MAIN_H
 
-#include <cstdio>
-#include <cstdint>
+#include "stdio.h"
+#include "stdint.h"
 
 #define internal static
 #define globalVar static
@@ -36,9 +36,23 @@ typedef float r32;
 
 #define MAX_WORDS_PER_LIST 1000
 
+typedef enum
+{
+	FunctionWords,
+	Punctuation,
+	Pronoun,
+	Verb, 
+	Adverb,
+	Adjective,
+	Preposition,
+	Determiners,
+	Profanities,
+	NUMBER_OF_TAGS
+}Word_Type_Tags_dt;
+
 struct WordList
 {
-    char *words[MAX_WORDS_PER_LIST] = {};
+    char *words[MAX_WORDS_PER_LIST];
     u32 count = 0;
 };
 


### PR DESCRIPTION
Fixed compiler error that was occurring in windows by modifying WordList
struct. Not sure if the same thing was occurring in Linux but here was
the problem:

https://msdn.microsoft.com/en-us/library/y19zxzb2.aspx

and the solution that worked:

http://stackoverflow.com/questions/7076494/fatal-error-c1001-an-internal-error-has-occurred-in-the-compiler

**I messed around with the build settings to get it working in windows as well so make sure not to pull the build in as well**
